### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+### Description
+
+{explain the changes you made here}
+
+### Scout rule, helpful cleanups
+
+- {write cleanup or remove this section}
+
+### What was tested
+
+{explain how tests were made and what was tested}
+
+### Issues
+
+Closes #{issue number}
+
+### General PR check list
+
+- [ ] Add tests for new domain logic
+- [ ] Update documentation (README + `/docs`) (remember that changes to the file structure must be explained in `/docs`)
+- [ ] Make sure PR author is listed in contributors
+- [ ] Keep PRs small, otherwise split into chunks
+- [ ] {add any check list item specific to your PR}
+
+### Results
+
+{please provide a screenshot, console outputs or anything to help us see what changed}


### PR DESCRIPTION
### Description

Adds GitHub templates

### What was tested

This PR was made using the template. I trust other changes.

### General PR check list

~~- [ ] Add tests for new domain logic~~
~~- [ ] Update documentation (README + `/docs`) (remember that changes to the file structure must be explained in `/docs`)~~
- [x] Make sure PR author is listed in contributors
- [x] Keep PRs small, otherwise split into chunks

### Results

We got templates!